### PR TITLE
Convert string 0 to 0px for react 0.15.

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
   "dependencies": {
     "babel": "~5.8.23",
     "babel-runtime": "~5.8.20",
-    "moment-twitter": "^0.2.0",
     "react": "0.14.0",
     "react-dom": "0.14.0",
     "react-videojs": "0.0.2",

--- a/src/components/Tweet/styles.js
+++ b/src/components/Tweet/styles.js
@@ -35,7 +35,7 @@ export default {
     'width': '48px',
     'height': '48px',
     'borderRadius': '5px',
-    'border': '0'
+    'border': '0px'
   },
   'fullname': {
     'fontWeight': 'bold',
@@ -83,7 +83,7 @@ export default {
     'paddingTop': '1px'
   },
   'ProfileTweetActionList': {
-    'fontSize': '0',
+    'fontSize': '0em',
     'lineHeight': '1',
     'marginTop': '10px',
     'display': 'block'
@@ -99,9 +99,9 @@ export default {
     'lineHeight': '1',
     'padding': '0 2px',
     'position': 'relative',
-    'border': '0',
+    'border': '0px',
     'background': 'transparent',
-    'margin': '0',
+    'margin': '0px',
     'WebkitAppearance': 'button',
     'cursor': 'pointer'
   },
@@ -175,9 +175,9 @@ export default {
   },
   'QuoteLink': {
     'height': '100%',
-    'left': '0',
+    'left': '0px',
     'position': 'absolute',
-    'top': '0',
+    'top': '0px',
     'width': '100%'
   },
   'QuoteTweetInner': {


### PR DESCRIPTION
We're using this with react 0.15 and seeing a ton of warnings in the console about CSS properties like `margin` getting the value `'0'`. I've converted all the instances of `'0'` to `'0px'`. I'm not actually sure if that's the appropriate solution or not, but it seems to have suppressed all the warnings on my setup. Merge at your own risk. :-)
