### PR TITLE
Dont check for window for universal rendering

### DIFF
--- a/src/components/Tweet/Video.js
+++ b/src/components/Tweet/Video.js
@@ -19,7 +19,7 @@ class Video extends React.Component {
       </video>
     )
 
-    if (typeof window.videojs !== 'undefined') {
+    if (typeof videojs !== 'undefined') {
       VideoComponent = (
         <VideoJS src={videoSrc} controls={!gif} autoPlay={gif} loop={gif} style={styles.video}>
           {'Your browser does not support the '}<code>{'video '}</code>{'element.'}


### PR DESCRIPTION
When doing server-side rendering, there is no `window` object, which causes a call to `window.videojs` to fail. The react-videojs module doesn't require `window`, it [just needs the global](https://github.com/wangzuo/react-videojs/blob/master/src/index.js#L11), so this removes the `window` and just checks to see if the `videojs` object exists globally.