### PR TITLE
change videojs wrapper to react 16 compatible dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "babel": "~5.8.23",
     "babel-runtime": "~5.8.20",
-    "react-videojs": "0.0.3",
+    "react-video-wrapper": "1.0.3",
     "twemoji": "^1.4.1",
     "twitter-text": "^1.13.2"
   }


### PR DESCRIPTION
this videojs wrapper is the same thing but works with react 16 and the deprecation of React.createClass