### PR TITLE
Add support for extended Tweets

### DIFF
--- a/src/components/Tweet/Tweet.js
+++ b/src/components/Tweet/Tweet.js
@@ -44,7 +44,24 @@ class Tweet extends React.Component {
     const {modalActive, modalIndex} = this.state
     let {data, linkProps} = this.props, isRT = false
     let MediaComponent = null, QuoteComponent = null
+    
+    //Support for extended tweets
+    if (data.full_text) {
+      data.text = data.full_text;
 
+      if (data.quoted_status) {
+        data.quoted_status.text = data.quoted_status.full_text;
+      }
+      
+      if (data.retweeted_status) {
+        data.retweeted_status.text = data.retweeted_status.full_text;
+
+        if (data.retweeted_status.quoted_status) {
+          data.retweeted_status.quoted_status.text = data.retweeted_status.quoted_status.full_text;
+        }
+      }
+    }
+    
     // use retweet as data if its a RT
     if (data.retweeted_status) {
       data = data.retweeted_status


### PR DESCRIPTION
In current version, `react-tweet` crashes when used with JSONs from extended tweets, because there is no `text` field anymore. Instead, there's `full_text`.

See here: [https://developer.twitter.com/en/docs/tweets/tweet-updates](https://developer.twitter.com/en/docs/tweets/tweet-updates)