### PR TITLE
Move babel dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,13 @@
   },
   "devDependencies": {
     "autoprefixer-core": "5.1.11",
+    "babel": "6.2.4",
+    "babel-cli": "6.2.0",
+    "babel-core": "6.26.0",
+    "babel-loader": "6.2.0",
+    "babel-plugin-transform-react-jsx": "6.24.1",
+    "babel-plugin-transform-runtime": "6.23.0",
+    "babel-preset-es2015": "6.24.1",
     "css-loader": "0.16.0",
     "ejs": "2.5.5",
     "extract-text-webpack-plugin": "0.8.2",
@@ -39,13 +46,6 @@
     "webpack-dev-server": "1.12.0"
   },
   "dependencies": {
-    "babel": "6.2.4",
-    "babel-cli": "6.2.0",
-    "babel-core": "6.26.0",
-    "babel-loader": "6.2.0",
-    "babel-plugin-transform-react-jsx": "6.24.1",
-    "babel-plugin-transform-runtime": "6.23.0",
-    "babel-preset-es2015": "6.24.1",
     "react-video-wrapper": "1.0.3",
     "twemoji": "1.4.1",
     "twitter-text": "1.13.2"


### PR DESCRIPTION
These babel-related dependencies are, I think, only used for building the library.